### PR TITLE
fix: image signing script.

### DIFF
--- a/hack/scripts/sign-images.sh
+++ b/hack/scripts/sign-images.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-EXTERNAL_OVERLAY_IMAGES=$(crane export "${OVERLAYS_IMAGE_REF}" | tar x --to-stdout overlays.yaml | yq '.overlays[] | .image + "@" + .digest')
+EXTERNAL_OVERLAY_IMAGES=$(crane export "${OVERLAYS_IMAGE_REF}" | tar x --to-stdout overlays.yaml | yq '.overlays | unique_by(.image) | .[] | .image + "@" + .digest')
 OVERLAY_IMAGE_DIGEST=$(crane digest "${OVERLAYS_IMAGE_REF}")
 
 for IMAGE in ${EXTERNAL_OVERLAY_IMAGES} ${OVERLAYS_IMAGE_REF}@${OVERLAY_IMAGE_DIGEST}; do


### PR DESCRIPTION
An overlay might support multiple SBC's from a single image. No point in trying to sign an already signed image. So select images to sign unique by image name.