### PR TITLE
release(v1.7.0-beta.0): prepare release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,54 @@
+## [overlays 1.7.0-beta.0](https://github.com/siderolabs/overlays/releases/tag/v1.7.0-beta.0) (2024-04-04)
+
+Welcome to the v1.7.0-beta.0 release of overlays!  
+*This is a pre-release of overlays*
+
+
+
+Please try out the release binaries and report any issues at
+https://github.com/siderolabs/overlays/issues.
+
+### SBC support
+
+Initial support for the following overlays:
+
+* [Raspberry Pi](https://github.com/siderolabs/sbc-raspberrypi/)
+* [RockChip](https://github.com/siderolabs/sbc-rockchip/)
+* [Jetson](https://github.com/siderolabs/sbc-jetson/)
+* [Allwinner](https://github.com/siderolabs/sbc-allwinner/)
+
+
+### Contributors
+
+* Noel Georgi
+
+### Changes
+<details><summary>6 commits</summary>
+<p>
+
+* [`f76bdf3`](https://github.com/siderolabs/overlays/commit/f76bdf3f4c95e7baa7a6ef318875d7371c91cd3c) chore: update sbc references
+* [`a0f9249`](https://github.com/siderolabs/overlays/commit/a0f9249e801c88e5d2883dbb87a2fc34381e8b1f) docs: add overlays docs
+* [`2aad9ab`](https://github.com/siderolabs/overlays/commit/2aad9ab6bec03dcccf466bb7e350845a31b1e4d6) fix: image signing script
+* [`61e6760`](https://github.com/siderolabs/overlays/commit/61e6760398e210f7acd5ba37ae1e40f4813b62a7) release(v1.7.0-alpha.1): prepare release
+* [`ad6a6ba`](https://github.com/siderolabs/overlays/commit/ad6a6ba134dedea1da8d161d4c422ea435fe377d) feat: add initial overlays
+* [`4bdd2d4`](https://github.com/siderolabs/overlays/commit/4bdd2d4942e2343335fbd54425d4a2c14488fc44) feat: initialize Overlays repo
+</p>
+</details>
+
+### Changes since v1.7.0-alpha.1
+<details><summary>3 commits</summary>
+<p>
+
+* [`f76bdf3`](https://github.com/siderolabs/overlays/commit/f76bdf3f4c95e7baa7a6ef318875d7371c91cd3c) chore: update sbc references
+* [`a0f9249`](https://github.com/siderolabs/overlays/commit/a0f9249e801c88e5d2883dbb87a2fc34381e8b1f) docs: add overlays docs
+* [`2aad9ab`](https://github.com/siderolabs/overlays/commit/2aad9ab6bec03dcccf466bb7e350845a31b1e4d6) fix: image signing script
+</p>
+</details>
+
+### Dependency Changes
+
+This release has no dependency changes
+
 ## [overlays 1.7.0-alpha.1](https://github.com/siderolabs/overlays/releases/tag/v1.7.0-alpha.1) (2024-03-18)
 
 Welcome to the v1.7.0-alpha.1 release of overlays!  


### PR DESCRIPTION
This is the official v1.7.0-beta.0 release.