### PR TITLE
backport: update sbc-rockchip to v0.1.0-beta.1

### DIFF
--- a/internal/overlays/overlays.yaml
+++ b/internal/overlays/overlays.yaml
@@ -2,17 +2,17 @@ overlays:
   - name: rpi_generic
     image: ghcr.io/siderolabs/sbc-raspberrypi:v0.1.0-beta.0
   - name: rockpi4
-    image: ghcr.io/siderolabs/sbc-rockchip:v0.1.0-beta.0
+    image: ghcr.io/siderolabs/sbc-rockchip:v0.1.0-beta.1
   - name: rockpi4c
-    image: ghcr.io/siderolabs/sbc-rockchip:v0.1.0-beta.0
+    image: ghcr.io/siderolabs/sbc-rockchip:v0.1.0-beta.1
   - name: rock4cplus
-    image: ghcr.io/siderolabs/sbc-rockchip:v0.1.0-beta.0
+    image: ghcr.io/siderolabs/sbc-rockchip:v0.1.0-beta.1
   - name: nanopi-r4s
-    image: ghcr.io/siderolabs/sbc-rockchip:v0.1.0-beta.0
+    image: ghcr.io/siderolabs/sbc-rockchip:v0.1.0-beta.1
   - name: rock64
-    image: ghcr.io/siderolabs/sbc-rockchip:v0.1.0-beta.0
+    image: ghcr.io/siderolabs/sbc-rockchip:v0.1.0-beta.1
   - name: orangepi-r1-plus-lts
-    image: ghcr.io/siderolabs/sbc-rockchip:v0.1.0-beta.0
+    image: ghcr.io/siderolabs/sbc-rockchip:v0.1.0-beta.1
   - name: jetson_nano
     image: ghcr.io/siderolabs/sbc-jetson:v0.1.0-beta.0
   - name: bananapi_m64


### PR DESCRIPTION
Brings in a fix https://github.com/siderolabs/sbc-rockchip/issues/10

Signed-off-by: Andrey Smirnov <andrey.smirnov@siderolabs.com>
(cherry picked from commit https://github.com/siderolabs/overlays/commit/37c057526a1c3cab8cce067fb767c68711f219d5)