### PR TITLE
release(v1.8.0-beta.0): prepare release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,53 @@
+## [overlays 1.8.0-beta.0](https://github.com/siderolabs/overlays/releases/tag/v1.8.0-beta.0) (2024-09-09)
+
+Welcome to the v1.8.0-beta.0 release of overlays!  
+*This is a pre-release of overlays*
+
+
+
+Please try out the release binaries and report any issues at
+https://github.com/siderolabs/overlays/issues.
+
+### SBC support
+
+Updates for the following overlays:
+
+* [Raspberry Pi](https://github.com/siderolabs/sbc-raspberrypi/)
+* [RockChip](https://github.com/siderolabs/sbc-rockchip/)
+
+
+### Contributors
+
+* Andrey Smirnov
+* Noel Georgi
+
+### Changes
+<details><summary>7 commits</summary>
+<p>
+
+* [`7f25263`](https://github.com/siderolabs/overlays/commit/7f25263d26aadd5c58f3fa0aa240af963a142c23) release(v1.8.0-alpha.2): prepare release
+* [`eab2050`](https://github.com/siderolabs/overlays/commit/eab2050382724b95da407cd8d760ff21d94687c0) chore: update overlays
+* [`9dfc7cc`](https://github.com/siderolabs/overlays/commit/9dfc7cc15ee9472add3240951ad7c930a8ff1408) release(v1.8.0-alpha.1): prepare release
+* [`6992852`](https://github.com/siderolabs/overlays/commit/6992852bb8b5633fed594bda0b366b524ac551e3) feat: bump overlays rockchip & raspberrypi
+* [`1a3848b`](https://github.com/siderolabs/overlays/commit/1a3848be2d0b6908d6f86019f4d20993145f0788) release(v1.8.0-alpha.0): prepare release
+* [`37c0575`](https://github.com/siderolabs/overlays/commit/37c057526a1c3cab8cce067fb767c68711f219d5) feat: update sbc-rockchip to v0.1.0-beta.1
+* [`c2bec3b`](https://github.com/siderolabs/overlays/commit/c2bec3b4a33c7a0b8eef628f6cfa47b5c0779329) release(v1.7.0-beta.0): prepare release
+</p>
+</details>
+
+### Changes since v1.8.0-alpha.2
+<details><summary>0 commit</summary>
+<p>
+
+</p>
+</details>
+
+### Dependency Changes
+
+This release has no dependency changes
+
+Previous release can be found at [v1.7.0](https://github.com/siderolabs/overlays/releases/tag/v1.7.0)
+
 ## [overlays 1.8.0-alpha.2](https://github.com/siderolabs/overlays/releases/tag/v1.8.0-alpha.2) (2024-08-30)
 
 Welcome to the v1.8.0-alpha.2 release of overlays!  


### PR DESCRIPTION
This is the official v1.8.0-beta.0 release.