### PR TITLE
backports: feat: update sbc-raspberrypi to v0.1.1

### DIFF
--- a/internal/overlays/overlays.yaml
+++ b/internal/overlays/overlays.yaml
@@ -1,6 +1,6 @@
 overlays:
   - name: rpi_generic
-    image: ghcr.io/siderolabs/sbc-raspberrypi:v0.1.0
+    image: ghcr.io/siderolabs/sbc-raspberrypi:v0.1.1
   - name: rockpi4
     image: ghcr.io/siderolabs/sbc-rockchip:v0.1.1
   - name: rockpi4c


### PR DESCRIPTION
See https://github.com/siderolabs/sbc-raspberrypi/releases/tag/v0.1.1

Signed-off-by: Andrey Smirnov <andrey.smirnov@siderolabs.com>
(cherry picked from commit 33050d303f76cbe3d19342e51238cf7f88b3e962)