### PR TITLE
backport: feat: update sbc-raspberrypi to v0.1.3

### DIFF
--- a/internal/overlays/overlays.yaml
+++ b/internal/overlays/overlays.yaml
@@ -1,6 +1,6 @@
 overlays:
   - name: rpi_generic
-    image: ghcr.io/siderolabs/sbc-raspberrypi:v0.1.2
+    image: ghcr.io/siderolabs/sbc-raspberrypi:v0.1.3
   - name: rockpi4
     image: ghcr.io/siderolabs/sbc-rockchip:v0.1.3
   - name: rockpi4c


### PR DESCRIPTION
See https://github.com/siderolabs/sbc-raspberrypi/releases/tag/v0.1.3

Signed-off-by: Andrey Smirnov <andrey.smirnov@siderolabs.com>
(cherry picked from commit f657517ce9c5bc7b3a2cf9b11352d87c3a994f83)