### PR TITLE
release(v1.12.0-alpha.0): prepare release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,29 @@
+## [overlays 1.12.0-alpha.0](https://github.com/siderolabs/overlays/releases/tag/v1.12.0-alpha.0) (2025-09-02)
+
+Welcome to the v1.12.0-alpha.0 release of overlays!  
+*This is a pre-release of overlays*
+
+
+
+Please try out the release binaries and report any issues at
+https://github.com/siderolabs/overlays/issues.
+
+### Contributors
+
+
+### Changes
+<details><summary>0 commit</summary>
+<p>
+
+</p>
+</details>
+
+### Dependency Changes
+
+This release has no dependency changes
+
+Previous release can be found at [v1.11.0](https://github.com/siderolabs/overlays/releases/tag/v1.11.0)
+
 ## [overlays 1.11.0-alpha.3](https://github.com/siderolabs/overlays/releases/tag/v1.11.0-alpha.3) (2025-07-02)
 
 Welcome to the v1.11.0-alpha.3 release of overlays!  

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -5,7 +5,7 @@ project_name = "overlays"
 github_repo = "siderolabs/overlays"
 match_deps = "^github.com/(siderolabs/[a-zA-Z0-9-]+)$"
 
-previous = "v1.10.0"
+previous = "v1.11.0"
 pre_release = true
 
 [notes]


### PR DESCRIPTION
This is the official v1.12.0-alpha.0 release.