### PR TITLE
fix: image-signer commands

### DIFF
--- a/.kres.yaml
+++ b/.kres.yaml
@@ -20,6 +20,8 @@ spec:
       toplevel: true
     - name: overlays
       toplevel: true
+    - name: $(ARTIFACTS)/image-signer
+      toplevel: true
     - name: sign-images
       toplevel: true
 ---
@@ -42,16 +44,29 @@ spec:
       - internal/overlays/overlays-generated.yaml
 ---
 kind: custom.Step
-name: sign-images
+name: $(ARTIFACTS)/image-signer
 spec:
   makefile:
     enabled: true
     phony: true
     variables:
-      - name: IMAGE_SIGNER_IMAGE
-        defaultValue: ghcr.io/siderolabs/image-signer:latest
+      - name: IMAGE_SIGNER_RELEASE
+        defaultValue: v0.1.1
     script:
       - |
-        @docker run --pull=always --rm --net=host $(IMAGE_SIGNER_IMAGE) sign \
+        @curl -sSL https://github.com/siderolabs/go-tools/releases/download/$(IMAGE_SIGNER_RELEASE)/image-signer-$(OPERATING_SYSTEM)-$(GOARCH) -o $(ARTIFACTS)/image-signer
+        @chmod +x $(ARTIFACTS)/image-signer
+---
+kind: custom.Step
+name: sign-images
+spec:
+  makefile:
+    enabled: true
+    phony: true
+    depends:
+      - $(ARTIFACTS)/image-signer
+    script:
+      - |
+        @$(ARTIFACTS)/image-signer sign \
           $(shell crane export $(OVERLAYS_IMAGE_REF) | tar x --to-stdout overlays.yaml | yq '.overlays | unique_by(.image) | .[] | .image + "@" + .digest') \
           $(OVERLAYS_IMAGE_REF)@$$(crane digest $(OVERLAYS_IMAGE_REF))

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2025-10-20T15:07:10Z by kres 46e133d.
+# Generated on 2025-10-30T03:43:47Z by kres cd5a938.
 
 # common variables
 
@@ -46,7 +46,7 @@ COMMON_ARGS += $(BUILD_ARGS)
 # extra variables
 
 OVERLAYS_IMAGE_REF ?= $(REGISTRY_AND_USERNAME)/overlays:$(TAG)
-IMAGE_SIGNER_IMAGE ?= ghcr.io/siderolabs/image-signer:latest
+IMAGE_SIGNER_RELEASE ?= v0.1.1
 
 # targets defines all the available targets
 
@@ -152,9 +152,14 @@ internal/overlays/overlays-generated.yaml:
 .PHONY: overlays
 overlays: internal/overlays/overlays-generated.yaml
 
+.PHONY: $(ARTIFACTS)/image-signer
+$(ARTIFACTS)/image-signer:
+	@curl -sSL https://github.com/siderolabs/go-tools/releases/download/$(IMAGE_SIGNER_RELEASE)/image-signer-$(OPERATING_SYSTEM)-$(GOARCH) -o $(ARTIFACTS)/image-signer
+	@chmod +x $(ARTIFACTS)/image-signer
+
 .PHONY: sign-images
-sign-images:
-	@docker run --pull=always --rm --net=host $(IMAGE_SIGNER_IMAGE) sign \
+sign-images: $(ARTIFACTS)/image-signer
+	@$(ARTIFACTS)/image-signer sign \
 	  $(shell crane export $(OVERLAYS_IMAGE_REF) | tar x --to-stdout overlays.yaml | yq '.overlays | unique_by(.image) | .[] | .image + "@" + .digest') \
 	  $(OVERLAYS_IMAGE_REF)@$$(crane digest $(OVERLAYS_IMAGE_REF))
 


### PR DESCRIPTION
Use the `image-signer` cli since we cannot pass in docker login credentials saved in keychain to `docker` container.