### PR TITLE
release(v1.12.0-beta.0): prepare release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,47 @@
+## [overlays 1.12.0-beta.0](https://github.com/siderolabs/overlays/releases/tag/v1.12.0-beta.0) (2025-11-14)
+
+Welcome to the v1.12.0-beta.0 release of overlays!  
+*This is a pre-release of overlays*
+
+
+
+Please try out the release binaries and report any issues at
+https://github.com/siderolabs/overlays/issues.
+
+### Contributors
+
+* Noel Georgi
+* Andrey Smirnov
+
+### Changes
+<details><summary>7 commits</summary>
+<p>
+
+* [`b1e6283`](https://github.com/siderolabs/overlays/commit/b1e6283faf3854284ee7b439b9e6918ec47e5591) feat: pull in new overlays
+* [`9e895dc`](https://github.com/siderolabs/overlays/commit/9e895dcb3cd379a93549056dd1532ace0d26f4ff) fix: image-signer commands
+* [`772ed88`](https://github.com/siderolabs/overlays/commit/772ed88c564bfce2061336be2e96f6b2171d41ef) release(v1.12.0-alpha.2): prepare release
+* [`ce6ae25`](https://github.com/siderolabs/overlays/commit/ce6ae25e6a9e2fe3a17471c647a3c3660575bf0f) feat: use `image-signer`
+* [`051b8c1`](https://github.com/siderolabs/overlays/commit/051b8c13069038f03f832049cefe50cb7fd72e7f) release(v1.12.0-alpha.1): prepare release
+* [`a58cc39`](https://github.com/siderolabs/overlays/commit/a58cc3981a05c2f632530e70d33a9e1987310bbb) feat: add new rockchip sbcs
+* [`abe467b`](https://github.com/siderolabs/overlays/commit/abe467bbc530575d625a27d74c6c5bb0de362b92) release(v1.12.0-alpha.0): prepare release
+</p>
+</details>
+
+### Changes since v1.12.0-alpha.2
+<details><summary>2 commits</summary>
+<p>
+
+* [`b1e6283`](https://github.com/siderolabs/overlays/commit/b1e6283faf3854284ee7b439b9e6918ec47e5591) feat: pull in new overlays
+* [`9e895dc`](https://github.com/siderolabs/overlays/commit/9e895dcb3cd379a93549056dd1532ace0d26f4ff) fix: image-signer commands
+</p>
+</details>
+
+### Dependency Changes
+
+This release has no dependency changes
+
+Previous release can be found at [v1.11.0](https://github.com/siderolabs/overlays/releases/tag/v1.11.0)
+
 ## [overlays 1.12.0-alpha.2](https://github.com/siderolabs/overlays/releases/tag/v1.12.0-alpha.2) (2025-10-27)
 
 Welcome to the v1.12.0-alpha.2 release of overlays!  


### PR DESCRIPTION
This is the official v1.12.0-beta.0 release.