### PR TITLE
chore: update sbc-raspberrypi overlay

### DIFF
--- a/internal/overlays/overlays.yaml
+++ b/internal/overlays/overlays.yaml
@@ -8,9 +8,9 @@ overlays:
   - name: jetson_nano
     image: ghcr.io/siderolabs/sbc-jetson:v0.1.3
   - name: revpi_generic
-    image: ghcr.io/siderolabs/sbc-raspberrypi:v0.1.6
+    image: ghcr.io/siderolabs/sbc-raspberrypi:v0.1.7
   - name: rpi_generic
-    image: ghcr.io/siderolabs/sbc-raspberrypi:v0.1.6
+    image: ghcr.io/siderolabs/sbc-raspberrypi:v0.1.7
   - name: helios64
     image: ghcr.io/siderolabs/sbc-rockchip:v0.1.7
   - name: nanopi-r4s


### PR DESCRIPTION
Update RaspberryPi overlay images to v0.1.7

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
