### PR TITLE
release(v1.13.0-alpha.0): prepare release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,31 @@
+## [overlays 1.13.0-alpha.0](https://github.com/siderolabs/overlays/releases/tag/v1.13.0-alpha.0) (2025-12-25)
+
+Welcome to the v1.13.0-alpha.0 release of overlays!  
+*This is a pre-release of overlays*
+
+
+
+Please try out the release binaries and report any issues at
+https://github.com/siderolabs/overlays/issues.
+
+### Contributors
+
+* Mateusz Urbanek
+
+### Changes
+<details><summary>1 commit</summary>
+<p>
+
+* [`44086a7`](https://github.com/siderolabs/overlays/commit/44086a7b25faf1eb72835bbc5cff9da9cfc725d6) chore: update sbc-raspberrypi overlay
+</p>
+</details>
+
+### Dependency Changes
+
+This release has no dependency changes
+
+Previous release can be found at [v1.12.0](https://github.com/siderolabs/overlays/releases/tag/v1.12.0)
+
 ## [overlays 1.12.0-alpha.2](https://github.com/siderolabs/overlays/releases/tag/v1.12.0-alpha.2) (2025-10-27)
 
 Welcome to the v1.12.0-alpha.2 release of overlays!  

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -5,18 +5,6 @@ project_name = "overlays"
 github_repo = "siderolabs/overlays"
 match_deps = "^github.com/(siderolabs/[a-zA-Z0-9-]+)$"
 
-previous = "v1.11.0"
+previous = "v1.12.0"
 pre_release = true
 
-[notes]
-    [rockchip]
-        title = "Rockchip SBCS"
-	description = """\
-New RockChip SBC's have been added:
-
-* odroid-m1
-* radxa-zero-3e
-* rock3b
-* orangepi-5-max
-* rock5t
-"""


### PR DESCRIPTION
This is the official v1.13.0-alpha.0 release.