### PR TITLE
backport: fix: typo with rpi_5 profile name

### DIFF
--- a/internal/overlays/overlays.yaml
+++ b/internal/overlays/overlays.yaml
@@ -11,7 +11,7 @@ overlays:
     image: ghcr.io/siderolabs/sbc-raspberrypi:v0.1.8
   - name: rpi_generic
     image: ghcr.io/siderolabs/sbc-raspberrypi:v0.1.8
-  - name: rpi5
+  - name: rpi_5
     image: ghcr.io/siderolabs/sbc-raspberrypi:v0.1.8
   - name: helios64
     image: ghcr.io/siderolabs/sbc-rockchip:v0.1.8


### PR DESCRIPTION
Missing underscore.


(cherry picked from commit 3d666988a0f5a12408edffbae41f00f35132ba32)