### PR TITLE
release(v1.14.0): prepare release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,51 @@
+## [overlays 1.14.0-rc.0](https://github.com/siderolabs/overlays/releases/tag/v1.14.0-rc.0) (2026-08-13)
+
+Welcome to the v1.14.0-rc.0 release of overlays!  
+*This is a pre-release of overlays*
+
+
+
+Please try out the release binaries and report any issues at
+https://github.com/siderolabs/overlays/issues.
+
+### Contributors
+
+* Andrey Smirnov
+* Maja Bojarska
+* Mateusz Urbanek
+* Noel Georgi
+
+### Changes
+<details><summary>9 commits</summary>
+<p>
+
+* [`1c7a59c`](https://github.com/siderolabs/overlays/commit/1c7a59c2e58625dac345e966d0e01d4ae334b099) chore: rekres, bump bldr
+* [`bcac37f`](https://github.com/siderolabs/overlays/commit/bcac37fabc4d26ab9687e7dbfc88e681973acdc7) feat: update SBC images for Rockchip and RPi
+* [`bf4f4a7`](https://github.com/siderolabs/overlays/commit/bf4f4a74765956e9852026083b2cd62a0e46cb8f) release(v1.14.0-beta.1): prepare release
+* [`3c0f15b`](https://github.com/siderolabs/overlays/commit/3c0f15b06fb821c98bb1a2ae22a560edc9a36042) release(v1.14.0-beta.0): prepare release
+* [`3e0ce53`](https://github.com/siderolabs/overlays/commit/3e0ce5319bd156de1b8f04576be8ff714b92f45f) chore: rekres
+* [`5802fa3`](https://github.com/siderolabs/overlays/commit/5802fa3e3de6691ef3c979feb0f2f201decaaf97) release(v1.14.0-alpha.2): prepare release
+* [`fcc20d3`](https://github.com/siderolabs/overlays/commit/fcc20d3a17ad76f726a1200c080a395d8cec8c52) fix: image-signer depends on _out dir
+* [`8348e2f`](https://github.com/siderolabs/overlays/commit/8348e2fcde307d0614bf7fc0d8b8c13affa7653d) release(v1.14.0-alpha.1): prepare release
+* [`ee045df`](https://github.com/siderolabs/overlays/commit/ee045dfbda76b5243eb1ed2f7d623293800f4359) release(v1.14.0-alpha.0): prepare release
+</p>
+</details>
+
+### Changes since v1.14.0-beta.1
+<details><summary>2 commits</summary>
+<p>
+
+* [`1c7a59c`](https://github.com/siderolabs/overlays/commit/1c7a59c2e58625dac345e966d0e01d4ae334b099) chore: rekres, bump bldr
+* [`bcac37f`](https://github.com/siderolabs/overlays/commit/bcac37fabc4d26ab9687e7dbfc88e681973acdc7) feat: update SBC images for Rockchip and RPi
+</p>
+</details>
+
+### Dependency Changes
+
+This release has no dependency changes
+
+Previous release can be found at [v1.13.0](https://github.com/siderolabs/overlays/releases/tag/v1.13.0)
+
 ## [overlays 1.14.0-beta.1](https://github.com/siderolabs/overlays/releases/tag/v1.14.0-beta.1) (2026-07-31)
 
 Welcome to the v1.14.0-beta.1 release of overlays!  


### PR DESCRIPTION
This is the official v1.14.0 release.